### PR TITLE
Python 2.7 : fix the Error while initiating child classes of BBGLowLe…

### DIFF
--- a/findatapy/market/datavendorbbg.py
+++ b/findatapy/market/datavendorbbg.py
@@ -314,7 +314,7 @@ class DataVendorBBGOpen(DataVendorBBG):
 ########################################################################################################################
 #### Lower level code to interact with Bloomberg Open API
 
-class BBGLowLevelTemplate:
+class BBGLowLevelTemplate(object): # in order that the init function works in child classes
 
     _session = None
 


### PR DESCRIPTION
…velTemplate

In python 2.7, the base class should inherit from object class in order that the child classes could use the super()