### PR TITLE
limit the threads to the number of CPUs

### DIFF
--- a/findatapy/market/marketdatagenerator.py
+++ b/findatapy/market/marketdatagenerator.py
@@ -319,6 +319,10 @@ class MarketDataGenerator(object):
             thread_no = DataConstants().market_thread_no[market_data_request_list[0].data_source]
 
         if thread_no > 0:
+            # limit the threads to the number of available CPUs
+            from multiprocessing import cpu_count
+            thread_no = min(cpu_count(),thread_no)
+            
             pool = Pool(thread_no)
 
             # open the market data downloads in their own threads and return the results


### PR DESCRIPTION
I have only 4 CPU and when I use 8 for bloomberg it just stopped working!! this limitation fixed the problem for me. We can solve the problem more elegantly by putting the limit in the parameters file.