### PR TITLE
fixing library required by findatapy\market\datavendorweb.py : import

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,5 +15,6 @@ setup(name='findatapy',
                           'pytz',
                           'requests',
                           'numpy',
-                          'pandas_datareader'],
+                          'pandas_datareader',
+                          'quandl'],
 	  zip_safe=False)


### PR DESCRIPTION
sorry to commit such a small change.
throws an error since I didn't have quandl module.